### PR TITLE
Add persistent volume for deployment

### DIFF
--- a/.helm/templates/deployment.yaml
+++ b/.helm/templates/deployment.yaml
@@ -39,11 +39,29 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         volumeMounts:
+        - name: {{ $.Values.werf.name }}
+          mountPath: /var/apps/{{ $.Values.werf.name }}
+          subPath: var
         - name: secret-volume
           readOnly: true
           subPath: ".env"
           mountPath: "/app/.env"
       volumes:
+      - name: {{ $.Values.werf.name }}
+        persistentVolumeClaim:
+          claimName: {{ $.Values.werf.name }}-pvc
       - name: secret-volume
         secret:
           secretName: {{ $.Values.werf.name }}-secret
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $.Values.werf.name }}-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nfs
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
- Add volumeMount for werf.name
- Add volume for werf.name
- Create PersistentVolumeClaim for werf.name
- Set storage class to nfs
- Request 2Gi storage
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Добавлено монтирование постоянного тома для развертывания, что улучшает управление данными.
- New Feature: Создан `PersistentVolumeClaim` с настройками для класса хранения `nfs`, обеспечивающий доступ на уровне `ReadWriteMany`.
- Enhancement: Увеличен объем запрашиваемого хранилища до 2Gi, что позволяет лучше справляться с нагрузкой.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->